### PR TITLE
removed the error catch for tag code

### DIFF
--- a/R/queryTestTagSite.R
+++ b/R/queryTestTagSite.R
@@ -19,9 +19,6 @@ queryTestTagSite = function(site_code = NULL,
                             year = NULL,
                             api_key = NULL) {
 
-  # need a tag code
-  stopifnot(!is.null(tag_code))
-
   if(is.null(year)) {
     year = lubridate::year(lubridate::today())
   }


### PR DESCRIPTION
The test tag function had a `stopifnot` call for an unnecessary tag code.  I removed the `stopifnot` function call.